### PR TITLE
Check route checkpoints for missing coordinates

### DIFF
--- a/Controllers/PatrolMapController.cs
+++ b/Controllers/PatrolMapController.cs
@@ -1,4 +1,4 @@
-﻿using AdminPortalV8.Libraries.ExtendedUserIdentity.Entities;
+using AdminPortalV8.Libraries.ExtendedUserIdentity.Entities;
 using AdminPortalV8.Models.Epatrol;
 using AdminPortalV8.Services;
 using Microsoft.AspNetCore.Mvc;
@@ -23,7 +23,7 @@ namespace AdminPortalV8.Controllers
             _ffmpegProcessService = ffmpegProcessService;
             _imageQualityAnalyzer = imageQualityAnalyzer;
         }
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(int? routeId)
         {
             ViewBag.Filter = true;
             try
@@ -55,6 +55,7 @@ namespace AdminPortalV8.Controllers
                     .ToListAsync();
 
                 ViewBag.Routes = routes;
+                ViewBag.SelectedRouteId = routeId;
 
                 var checkpointsWithCameras = new List<object>();
 

--- a/Views/Patrol/Index.cshtml
+++ b/Views/Patrol/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@{
+@{
     ViewBag.Title = "Patrol";
 }
 
@@ -60,7 +60,54 @@
                 }
 
                 handleStartPatrol(button);
-                startPatrolCycle(routeId, cameraIp, duration);
+
+                // Validate coordinates before starting auto patrol
+                $.get('/Patrol/ValidateRouteCoordinates', { routeId: routeId })
+                    .done(function (res) {
+                        if (res && res.requiresCoordinateSetup) {
+                            showCoordinateAlert(res.routeId, res.routeName);
+                            const button = $(`button[data-route-id="${routeId}"].start-patrol`);
+                            button.removeClass('disabled');
+                            button.css('pointer-events', 'auto');
+                            button.html('<i class="fas fa-play"></i> Start Auto Patrol');
+                            return;
+                        }
+                        startPatrolCycle(routeId, cameraIp, duration);
+                    })
+                    .fail(function () {
+                        showToast('Failed to validate route coordinates', 'red');
+                        const button = $(`button[data-route-id="${routeId}"].start-patrol`);
+                        button.removeClass('disabled');
+                        button.css('pointer-events', 'auto');
+                        button.html('<i class="fas fa-play"></i> Start Auto Patrol');
+                    });
+            });
+
+            // Intercept manual Start links to validate before navigating
+            $('#route-table').on('click', 'a[href^="/Patrol/StartPatrolling"]', function (e) {
+                var url = new URL(this.href, window.location.origin);
+                var routeId = url.searchParams.get('routeId');
+                var anchor = this;
+                e.preventDefault();
+                handleButtonClick(anchor);
+
+                $.get('/Patrol/ValidateRouteCoordinates', { routeId: routeId })
+                    .done(function (res) {
+                        if (res && res.requiresCoordinateSetup) {
+                            showCoordinateAlert(res.routeId, res.routeName);
+                            anchor.classList.remove('disabled');
+                            anchor.style.pointerEvents = 'auto';
+                            anchor.innerHTML = '<i class="fas fa-play"></i> Start';
+                        } else {
+                            window.location.href = anchor.href;
+                        }
+                    })
+                    .fail(function () {
+                        showToast('Failed to validate route coordinates', 'red');
+                        anchor.classList.remove('disabled');
+                        anchor.style.pointerEvents = 'auto';
+                        anchor.innerHTML = '<i class=\'fas fa-play\'></i> Start';
+                    });
             });
 
             $('#route-table').on('click', '.stop-patrol', function () {
@@ -109,6 +156,9 @@
 
                         patrolTimers[routeId] = { stopTimer };
                     } else {
+                        if (response.requiresCoordinateSetup) {
+                            showCoordinateAlert(response.routeId || routeId, response.routeName);
+                        }
                         showToast(response.message, 'red');
                         const button = $(`button[data-route-id="${routeId}"].start-patrol`);
                         button.removeClass('disabled');
@@ -117,6 +167,9 @@
                     }
                 },
                 error: function (xhr) {
+                    if (xhr.responseJSON && xhr.responseJSON.requiresCoordinateSetup) {
+                        showCoordinateAlert(xhr.responseJSON.routeId || routeId, xhr.responseJSON.routeName);
+                    }
                     var errorMessage = xhr.responseJSON?.message || 'Error starting auto patrol';
                     showToast(errorMessage, 'red');
                     const button = $(`button[data-route-id="${routeId}"].start-patrol`);
@@ -199,6 +252,23 @@
             document.body.appendChild(toast);
             setTimeout(() => (toast.style.opacity = "0"), 1000);
             setTimeout(() => document.body.removeChild(toast), 1500);
+        }
+
+        function showCoordinateAlert(routeId, routeName) {
+            var modal = document.getElementById('coordinateAlertModal');
+            var msg = document.getElementById('coordinateAlertMessage');
+            var btn = document.getElementById('coordinateAlertNavBtn');
+            msg.textContent = `This route ('${routeName || ''}') still has checkpoint(s) without camera coordinates. Please set them in Patrol Map.`;
+            btn.onclick = function () {
+                window.location.href = `/PatrolMap/Index?routeId=${routeId}`;
+            };
+            if (typeof $ !== 'undefined' && $.fn && $.fn.modal) {
+                $(modal).modal('show');
+            } else {
+                if (window.confirm(msg.textContent + '\n\nOpen Patrol Map now?')) {
+                    btn.onclick();
+                }
+            }
         }
     </script>
 }
@@ -317,6 +387,25 @@
                     }
                 </tbody>
             </table>
+        </div>
+        <!-- Coordinate Alert Modal -->
+        <div class="modal fade" id="coordinateAlertModal" tabindex="-1" role="dialog" aria-labelledby="coordinateAlertModalLabel" aria-hidden="true">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="coordinateAlertModalLabel">Missing Camera Coordinates</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <p id="coordinateAlertMessage"></p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-primary" id="coordinateAlertNavBtn">Go to Patrol Map</button>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </body>

--- a/Views/PatrolMap/Index.cshtml
+++ b/Views/PatrolMap/Index.cshtml
@@ -1,4 +1,4 @@
-﻿@using AdminPortalV8.Helpers
+@using AdminPortalV8.Helpers
 @model AdminPortalV8.Models.Epatrol.Route
 @{
     ViewBag.Title = "Patrol Map";
@@ -19,6 +19,33 @@
 @section scripts {
     <script>
         $(document).ready(function () {
+            // Preselect route if provided via query param or server ViewBag
+            var preselectedRouteId = '@(ViewBag.SelectedRouteId ?? "")';
+            if (preselectedRouteId && preselectedRouteId !== '0') {
+                setTimeout(function(){
+                    var selectEl = document.getElementById('route');
+                    if (selectEl) {
+                        selectEl.value = preselectedRouteId;
+                        if (selectEl.value === preselectedRouteId) {
+                            showImage();
+                        }
+                    }
+                }, 0);
+            } else {
+                // Fallback to localStorage if previously saved
+                var lsRouteId = localStorage.getItem('selectedRouteId');
+                if (lsRouteId) {
+                    setTimeout(function(){
+                        var selectEl = document.getElementById('route');
+                        if (selectEl) {
+                            selectEl.value = lsRouteId;
+                            if (selectEl.value === lsRouteId) {
+                                showImage();
+                            }
+                        }
+                    }, 0);
+                }
+            }
             $('#setCameraBtn').on('click', function () {
                 var routeId = document.getElementById("route").value;
                 var checkpointId = document.getElementById("checkpointId").value;


### PR DESCRIPTION
Add validation to prevent starting patrols on routes with missing checkpoint coordinates and guide users to the Patrol Map for setup.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c16557c-cd9a-47f7-9413-574e59e5c121">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c16557c-cd9a-47f7-9413-574e59e5c121">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

